### PR TITLE
fix: avoid remote add failure

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -17,6 +17,7 @@ export class Git {
   }
 
   async init(): Promise<void> {
+    this.git('remote', 'remove', RemoteName);
     this.git('remote', 'add', RemoteName, this.url);
     this.git('config', '--global', 'user.name', this.actor);
     this.git('config', '--global', 'user.email', this.email);


### PR DESCRIPTION
`fatal: remote origin already exists.` is happening on self-hosted runner.